### PR TITLE
Fix/evm stop

### DIFF
--- a/evm
+++ b/evm
@@ -78,7 +78,7 @@ _get_current_es_version() {
 }
 
 _get_current_es_pid() {
-  ps -ef | grep -i [E]lasticsearch | awk '{print $2}'
+  ps -ef | grep -i [E]lasticsearch.pid | awk '{print $2}'
   # if [[ -f "${PID_FILE}" ]]; then
   #   cat "${PID_FILE}"
   # fi

--- a/evm
+++ b/evm
@@ -8,7 +8,7 @@
 # Author: Duy Do (duydo)
 # Contributors: Quang Nguyen (xluffy), Nham Le (nhamlh)
 
-readonly EVM_VERSION="0.1.5"
+readonly EVM_VERSION="0.1.6"
 
 readonly OS="$(uname | tr '[:upper:]' '[:lower:]')"
 readonly OS_TYPE="$(uname -m)"


### PR DESCRIPTION
Hey,

`evm stop` was broken for me because the grep returned two pids - one for the elasticsearch process and one for some kind of elasticsearch controller process. By adjusting the `grep` inside `get_current_es_pid` to be more strict it's working again for me :)