### PR TITLE
Add M1 processors support

### DIFF
--- a/evm
+++ b/evm
@@ -4,7 +4,7 @@
 # Purpose: Managing multiple Elasticsearch versions on your local development machine
 # Licence: Apache License, version 2 (http://www.apache.org/licenses/LICENSE-2.0)
 # Source: https://github.com/duydo/evm
-# Version: 0.1.8
+# Version: 0.1.9
 # Author: Duy Do (duydo)
 # Contributors: Quang Nguyen (xluffy), Nham Le (nhamlh)
 
@@ -93,8 +93,18 @@ _detect_checksum_cmd() {
 
 _get_downloaded_file_name(){
   local version="$1"
-  if [[ ${version:0:1} -ge 7 ]] ; then
-    echo "${ES_NAME}-${version}-${OS}-${OS_TYPE}.${DOWNLOAD_EXT}"
+  local version_array=(${version//./ })
+  local os_type="$OS_TYPE"
+  local m1_platform="arm64"
+  if [[ ${version_array[0]} -ge 7 ]] ; then
+    if [[ "$OS_TYPE" == "$m1_platform" ]]; then
+      if [[ (${version_array[0]} -eq 7) && (${version_array[1]} -le 15) ]] ; then
+        os_type="x86_64"
+      else
+        os_type="aarch64"
+      fi
+    fi
+    echo "${ES_NAME}-${version}-${OS}-${os_type}.${DOWNLOAD_EXT}"
   else
     echo "${ES_NAME}-${version}.${DOWNLOAD_EXT}"
   fi


### PR DESCRIPTION
# Problem
1. `uname -m` command responsible for setting `$OS_TYPE` variable is returning `arm64` value on the M1 Macs. As a result evm is not able to trace M1 compatible ElasticSearch versions because for some (historical?) reasons these packages are tagged with `aarch64` postfix in the release archive.
2. ARM64 architecture is officially supported by Elastic only starting from release 7.16.0 on the M1 Macs (even though older x86_64 are perfectly functional)

![Screen Shot 2022-08-13 at 11 23 18 am](https://user-images.githubusercontent.com/160712/185724884-249a88b9-2562-4c35-b26f-31926d0a5c03.png)

# Solution
This PR is adding a new condition that's replacing `os_stype` variable value from `arm64` to `aarch64` (for modern ES versions) OR explicitly applying `x86_64` package postfix for legacy (older than 7.16.0) versions.

![Screen Shot 2022-08-20 at 11 43 02](https://user-images.githubusercontent.com/160712/185725372-18584477-7f6b-4897-8464-fb224a3ec169.png)
![Screen Shot 2022-08-20 at 11 43 36](https://user-images.githubusercontent.com/160712/185725373-c05f9900-3345-437f-8f43-eb565d1676f6.png)
![Screen Shot 2022-08-20 at 11 44 14](https://user-images.githubusercontent.com/160712/185725374-2a8e2ae6-5929-4553-b8c8-993cff289472.png)
![Screen Shot 2022-08-20 at 11 45 14](https://user-images.githubusercontent.com/160712/185725376-e957f016-c275-4e4b-922c-9e9f9b4b4139.png)
